### PR TITLE
Add Cocoapods podspec

### DIFF
--- a/MastodonClient.podspec
+++ b/MastodonClient.podspec
@@ -1,0 +1,22 @@
+Pod::Spec.new do |s|
+  s.name             = 'MastodonClient'
+  s.version          = '1.0.1'
+  s.summary          = 'A Swift / RxSwift / Moya / Gloss based API client for Mastodon instances.'
+
+  s.description      = <<-DESC
+This client can be used to interact with Mastodon instances. It`s recommended to be used with RxSwift.
+                       DESC
+
+  s.homepage         = 'https://github.com/kimar/Mastodon.swift'
+  s.license          = { :type => 'MIT', :file => 'LICENSE' }
+  s.author           = { 'git' => 'marcus@kida.io' }
+  s.source           = { :git => 'https://github.com/kimar/Mastodon.swift.git', :tag => s.version.to_s }
+
+  s.ios.deployment_target = '9.0'
+  s.osx.deployment_target = '10.10'
+
+  s.source_files = 'Sources/**/*'
+
+  s.dependency 'Moya/RxSwift', '~> 8.0.3'
+  s.dependency 'Moya-Gloss/RxSwift', '~> 2.0.0'
+end

--- a/MastodonClient.podspec
+++ b/MastodonClient.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'MastodonClient'
-  s.version          = '1.0.1'
+  s.version          = '1.0.2'
   s.summary          = 'A Swift / RxSwift / Moya / Gloss based API client for Mastodon instances.'
 
   s.description      = <<-DESC

--- a/MastodonClient.podspec
+++ b/MastodonClient.podspec
@@ -15,7 +15,7 @@ This client can be used to interact with Mastodon instances. It`s recommended to
   s.ios.deployment_target = '9.0'
   s.osx.deployment_target = '10.10'
 
-  s.source_files = 'Sources/**/*'
+  s.source_files = 'Sources/**/*.swift'
 
   s.dependency 'Moya/RxSwift', '~> 8.0.3'
   s.dependency 'Moya-Gloss/RxSwift', '~> 2.0.0'

--- a/Sources/MastodonClient.swift
+++ b/Sources/MastodonClient.swift
@@ -2,9 +2,14 @@ import Foundation
 import Alamofire
 import Moya
 import RxSwift
+
+#if COCOAPODS
+import Moya_Gloss
+#else
 import RxMoya
 import MoyaGloss
 import RxMoyaGloss
+#endif
 
 public typealias Scope = String
 public typealias Scopes = [Scope]


### PR DESCRIPTION
This add back a working podspec. 

To use it add following to Podfile:
```
pod 'MastodonClient', git: "https://github.com/siuying/Mastodon.swift.git", branch: "cocoapods"
```