### PR TITLE
Implement public function to be able to consume all TargetTypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,21 @@
 
 ## Howto
 
-This client is designed to connect to any Mastodon instance and interact with it. As of the time of writing this (08th April 2017) the Moya Providers are feature complete with [tootsuite/mastodon](https://github.com/tootsuite/mastodon).
+This client is designed to connect to any Mastodon instance and interact with it.
 
-`MastodonClient` contains a few convenience methods to create Apps (OAuth Clients) and interact with the API but you should use the Moya Targets directly for the time being (as those are feature complete).
+`MastodonClient` contains a few convenience methods to create Apps (OAuth Clients) and interact with the API but you should use the URLSession TargetTypes directly for the time being (as those are feature complete), e.g. for getting your Home Timeline:
+
+```swift
+let request = try MastodonClient.request(
+    for: URL(string: "https://mastodon.social")!,
+    target: Mastodon.Timelines.home(nil, nil),
+    withBearerToken: token
+)
+
+let (data, _) = try await session.data(for: request)
+
+let result = try JSONDecoder().decode([Status].self, from: data)
+```
 
 Given you've got an OAuth Client
 
@@ -18,7 +30,7 @@ let app = App(clientId: "…", clientSecret: "…")
 Logging in is as easy as this then:
 
 ```swift
-let client = MastodonClient(baseURL: URL(string: "https://host.tld")!)
+let client = MastodonClient(baseURL: URL(string: "https://mastodon.tld")!)
 
 let app = App(
     clientId: "a1a2a3a4a5",
@@ -36,7 +48,7 @@ let response = try await client.getToken(
 Provided login was successful and you've retrieved an `AccessToken` you're free to use all the other APIs, e.g. to retrieve your home timeline using `MastodonClientAuthenticated` e.g.:
 
 ```swift
-let client = MastodonClient(baseURL: URL(string: "https://bearologics.social")!)
+let client = MastodonClient(baseURL: URL(string: "https://mastodon.tld")!)
     .getAuthenticated(token: token)
 
 let result = try await client.getHomeTimeline()

--- a/Sources/MastodonSwift/MastodonClient+Convenience.swift
+++ b/Sources/MastodonSwift/MastodonClient+Convenience.swift
@@ -1,0 +1,45 @@
+//
+//  File.swift
+//  
+//
+//  Created by Marcus Kida on 02.11.22.
+//
+
+import Foundation
+
+public extension MastodonClient {
+    func createApp(named name: String,
+                          redirectUri: String = "urn:ietf:wg:oauth:2.0:oob",
+                          scopes: Scopes,
+                          website: URL) async throws -> App {
+        
+        let request = try Self.request(
+            for: baseURL,
+            target: Mastodon.Apps.register(
+                clientName: name,
+                redirectUris: redirectUri,
+                scopes: scopes.reduce("") { $0 == "" ? $1 : $0 + " " + $1},
+                website: website.absoluteString
+            )
+        )
+        
+        let (data, _) = try await urlSession.data(for: request)
+        
+        return try JSONDecoder().decode(App.self, from: data)
+    }
+    
+    func getToken(withApp app: App,
+                         username: String,
+                         password: String,
+                         scope: Scopes) async throws -> AccessToken {
+
+        let request = try Self.request(
+            for: baseURL,
+            target: Mastodon.OAuth.authenticate(app, username, password, scope.reduce("") { $0 == "" ? $1 : $0 + " " + $1})
+        )
+        
+        let (data, _) = try await urlSession.data(for: request)
+        
+        return try JSONDecoder().decode(AccessToken.self, from: data)
+    }
+}

--- a/Sources/MastodonSwift/Networking/TargetType.swift
+++ b/Sources/MastodonSwift/Networking/TargetType.swift
@@ -15,37 +15,12 @@ public enum Method: String {
     case delete = "DELETE", get = "GET", head = "HEAD", patch = "PATCH", post = "POST", put = "PUT"
 }
 
-protocol TargetType {
+public protocol TargetType {
     var path: String { get }
     var method: Method { get }
     var headers: [String: String]? { get }
     var queryItems: [String: String]? { get }
     var httpBody: Data? { get }
-}
-
-extension URLSession {
-    func request(for baseURL: URL, target: TargetType, withBearerToken token: String? = nil) throws -> URLRequest {
-        
-        var urlComponents = URLComponents(url: baseURL.appendingPathComponent(target.path), resolvingAgainstBaseURL: false)
-        urlComponents?.queryItems = target.queryItems?.map { URLQueryItem(name: $0.0, value: $0.1) }
-        
-        guard let url = urlComponents?.url else { throw NetworkingError.cannotCreateUrlRequest }
-        
-        var request = URLRequest(url: url)
-        
-        target.headers?.forEach { header in
-            request.setValue(header.1, forHTTPHeaderField: header.0)
-        }
-        
-        if let token = token {
-            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
-        }
-        
-        request.httpMethod = target.method.rawValue
-        request.httpBody = target.httpBody
-        
-        return request
-    }
 }
 
 extension [String: String] {

--- a/Tests/MastodonSwiftTests/MastodonClientTests.swift
+++ b/Tests/MastodonSwiftTests/MastodonClientTests.swift
@@ -65,6 +65,27 @@ class MastodonSwiftTests: XCTestCase {
         XCTAssertEqual(result.first?.content, "<p>TEST</p>")
     }
     
+    func testGetHomeTimeline_withoutConvenienceMethod() async throws {
+        let token = "s3cr3t_t0k3n"
+        
+        MockURLProtocol.error = nil
+        MockURLProtocol.requestHandler = { _ in
+            getHomeTinelineMockResponse
+        }
+        
+        let request = try MastodonClient.request(
+            for: URL(string: "https://bearologics.social")!,
+            target: Mastodon.Timelines.home(nil, nil),
+            withBearerToken: token
+        )
+        
+        let (data, _) = try await session.data(for: request)
+        
+        let result = try JSONDecoder().decode([Status].self, from: data)
+        
+        XCTAssertEqual(result.first?.content, "<p>TEST</p>")
+    }
+    
     func testGetPublicTimeline() async throws {
         let token = "s3cr3t_t0k3n"
         


### PR DESCRIPTION
After my big refactoring there was no convenient way to consume all APIs, not just those exposed via `MastodonClient`. Also I've updated the [README](README.md) on how to use the new `TargetType`s.