### PR TITLE
Add support for watchOS

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,8 @@ let package = Package(
     name: "MastodonSwift",
     platforms: [
         .iOS(.v13),
-        .macOS(.v12)
+        .macOS(.v12),
+        .watchOS(.v8)
     ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.


### PR DESCRIPTION
Picked watchOS 8 a bit arbitrarily (going after the n-1 scheme). We could potentially also go lower.