### PR TITLE
added test for MastodonClient.readInstanceInformation

### DIFF
--- a/Tests/MastodonSwiftTests/MastodonClientTests.swift
+++ b/Tests/MastodonSwiftTests/MastodonClientTests.swift
@@ -54,7 +54,7 @@ class MastodonSwiftTests: XCTestCase {
         
         MockURLProtocol.error = nil
         MockURLProtocol.requestHandler = { _ in
-            getHomeTinelineMockResponse
+            getHomeTimelineMockResponse
         }
         
         let client = MastodonClient(baseURL: URL(string: "https://bearologics.social")!, urlSession: session)
@@ -70,7 +70,7 @@ class MastodonSwiftTests: XCTestCase {
         
         MockURLProtocol.error = nil
         MockURLProtocol.requestHandler = { _ in
-            getHomeTinelineMockResponse
+            getHomeTimelineMockResponse
         }
         
         let request = try MastodonClient.request(
@@ -91,7 +91,7 @@ class MastodonSwiftTests: XCTestCase {
         
         MockURLProtocol.error = nil
         MockURLProtocol.requestHandler = { _ in
-            getHomeTinelineMockResponse
+            getHomeTimelineMockResponse
         }
         
         let client = MastodonClient(baseURL: URL(string: "https://bearologics.social")!, urlSession: session)
@@ -107,7 +107,7 @@ class MastodonSwiftTests: XCTestCase {
         
         MockURLProtocol.error = nil
         MockURLProtocol.requestHandler = { _ in
-            getHomeTinelineMockResponse
+            getHomeTimelineMockResponse
         }
         
         let client = MastodonClient(baseURL: URL(string: "https://bearologics.social")!, urlSession: session)

--- a/Tests/MastodonSwiftTests/MastodonClientTests.swift
+++ b/Tests/MastodonSwiftTests/MastodonClientTests.swift
@@ -117,6 +117,20 @@ class MastodonSwiftTests: XCTestCase {
         
         XCTAssertEqual(result.first?.content, "<p>TEST</p>")
     }
+    
+    func testReadInstanceInformation() async throws {
+        MockURLProtocol.error = nil
+        MockURLProtocol.requestHandler = { _ in
+            readInstanceInformationMockResponse
+        }
+        let client = MastodonClient(baseURL: URL(string: "https://bearologics.social")!, urlSession: session)
+        let result = try await client.readInstanceInformation()
+        XCTAssertEqual(result.title,"Bearologics.social")
+        XCTAssertEqual(result.uri,"bearologics.social")
+        XCTAssertEqual(result.email,"mastodon@bearologics.com")
+        XCTAssertEqual(result.description,"")
+        XCTAssertNotNil(result.thumbnail)
+    }
 
     static var allTests = [
         ("testAuthentication", testAuthentication),

--- a/Tests/MastodonSwiftTests/Mocking/Responses/GetHomeTimelineMockResponse.swift
+++ b/Tests/MastodonSwiftTests/Mocking/Responses/GetHomeTimelineMockResponse.swift
@@ -124,4 +124,4 @@ let getHomeTimelineMockUrlResponse = HTTPURLResponse(
     headerFields: nil
 )!
 
-let getHomeTinelineMockResponse = (getHomeTimelineMockUrlResponse, getHomeTimelineMockResponseData)
+let getHomeTimelineMockResponse = (getHomeTimelineMockUrlResponse, getHomeTimelineMockResponseData)

--- a/Tests/MastodonSwiftTests/Mocking/Responses/ReadInstanceInformationMockResponse.swift
+++ b/Tests/MastodonSwiftTests/Mocking/Responses/ReadInstanceInformationMockResponse.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+// portion of
+// curl https://bearologics.social/api/v1/instance -H "Accept: application/json"
+let readInstanceInformationMockResponseData = """
+{"uri":"bearologics.social","title":"Bearologics.social","short_description":"","description":"","email":"mastodon@bearologics.com","version":"4.0.2","urls":{"streaming_api":"wss://bearologics.social"},"stats":{"user_count":7,"status_count":896,"domain_count":7528},"thumbnail":"https://files.bearologics.social/site_uploads/files/000/000/001/@1x/49799467c94c92bb.png"}
+""".data(using: .utf8)!
+
+let readInstanceInformationMockUrlResponse = HTTPURLResponse(
+    url: URL(string: "https://bearologics.social/api/v1/instance")!,
+    statusCode: 200,
+    httpVersion: nil,
+    headerFields: nil
+)!
+
+let readInstanceInformationMockResponse = (readInstanceInformationMockUrlResponse, readInstanceInformationMockResponseData)


### PR DESCRIPTION
I added a test for MastodonClient.readInstanceInformation, tried to follow the same pattern as the existing tests. I used curl to grap a subset of the bearologics instance info for the mock test response.