### PR TITLE
Add tvOS support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,8 @@ let package = Package(
     platforms: [
         .iOS(.v13),
         .macOS(.v12),
-        .watchOS(.v8)
+        .watchOS(.v8),
+        .tvOS(.v15)
     ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.


### PR DESCRIPTION
I added tvOS 15 as the minimum supported version, which allows it to build and work in a tvOS app (I was getting the error `'data(for:delegate:)' is only available in tvOS 15.0 or newer`).